### PR TITLE
Configurable table name

### DIFF
--- a/lib/web/plug.ex
+++ b/lib/web/plug.ex
@@ -51,7 +51,6 @@ defmodule FT.K8S.TrafficDrainPlug do
   @impl true
   def call(conn, _config), do: conn
 
-  @impl true
   defp draining_request(conn, table_name) do
     draining = FT.K8S.TrafficDrainHandler.draining?(table_name)
 

--- a/lib/web/plug.ex
+++ b/lib/web/plug.ex
@@ -39,18 +39,21 @@ defmodule FT.K8S.TrafficDrainPlug do
 
   @impl true
   def init(options) do
-    Keyword.get(options, :request_path, "/__traffic")
+    {
+      Keyword.get(options, :request_path, "/__traffic"),
+      Keyword.get(options, :table_name, :connection_drain_table)
+    }
   end
 
   @impl true
-  def call(%Plug.Conn{request_path: path} = conn, path), do: draining_request(conn)
+  def call(%Plug.Conn{request_path: path} = conn, {path, table_name}), do: draining_request(conn, table_name)
 
   @impl true
   def call(conn, _config), do: conn
 
   @impl true
-  defp draining_request(conn) do
-    draining = FT.K8S.TrafficDrainHandler.draining?()
+  defp draining_request(conn, table_name) do
+    draining = FT.K8S.TrafficDrainHandler.draining?(table_name)
 
     case draining do
       true ->

--- a/lib/web/plug.ex
+++ b/lib/web/plug.ex
@@ -35,14 +35,21 @@ defmodule FT.K8S.TrafficDrainPlug do
   """
 
   import Plug.Conn
-
   @behaviour Plug
 
   @impl true
-  def init(options), do: options
+  def init(options) do
+    Keyword.get(options, :request_path, "/__traffic")
+  end
 
   @impl true
-  def call(conn = %{path_info: ["__traffic"]}, _config) do
+  def call(%Plug.Conn{request_path: path} = conn, path), do: draining_request(conn)
+
+  @impl true
+  def call(conn, _config), do: conn
+
+  @impl true
+  defp draining_request(conn) do
     draining = FT.K8S.TrafficDrainHandler.draining?()
 
     case draining do
@@ -58,8 +65,5 @@ defmodule FT.K8S.TrafficDrainPlug do
         |> halt
     end
   end
-
-  @impl true
-  def call(conn, _config), do: conn
 
 end

--- a/test/handler_test.exs
+++ b/test/handler_test.exs
@@ -23,4 +23,25 @@ defmodule K8STrafficDrainHandlerTest do
     assert time >= delay * 1000, "expected stop after delay time"
     assert time < ((delay + 100) * 1000), "expected stopping message within 100ms of delay time"
   end
+
+  test "SIGTERM starts draining, then stops after delay with custom table name" do
+    delay = 75
+
+    start_supervised({@handler, [shutdown_delay_ms: delay, test_mode: self(), table_name: :test123]})
+
+    refute @handler.draining?(:test123)
+
+    {time, _} = :timer.tc(fn ->
+      :gen_event.notify(:erl_signal_server, :sigterm)
+      assert_receive :draining
+      refute_received {:stopping, _}
+      assert @handler.draining?(:test123), "expected draining to have started"
+
+      assert_receive {:stopping, state}, delay * 2
+      assert  {_, ^delay, _} = state
+    end)
+
+    assert time >= delay * 1000, "expected stop after delay time"
+    assert time < ((delay + 100) * 1000), "expected stopping message within 100ms of delay time"
+  end
 end

--- a/test/plug_test.exs
+++ b/test/plug_test.exs
@@ -10,7 +10,8 @@ defmodule K8STrafficDrainPlugTest do
     refute @handler.draining?()
 
     conn = conn(:get, "/__traffic")
-    conn = FT.K8S.TrafficDrainPlug.call(conn, [])
+    config = FT.K8S.TrafficDrainPlug.init([])
+    conn = FT.K8S.TrafficDrainPlug.call(conn, config)
     assert conn.status == 200
     assert conn.halted
     refute @handler.draining?()
@@ -25,17 +26,85 @@ defmodule K8STrafficDrainPlugTest do
     assert @handler.draining?()
 
     conn = conn(:get, "/__traffic")
-    conn = FT.K8S.TrafficDrainPlug.call(conn, [])
+    config = FT.K8S.TrafficDrainPlug.init([])
+    conn = FT.K8S.TrafficDrainPlug.call(conn, config)
     assert conn.status == 500
     assert conn.halted
 
     assert_receive {:stopping, _}
   end
 
-  test "plug passes through other requests" do
+  test "configured path endpoint returns 200 normally" do
+    start_supervised({@handler, [shutdown_delay_ms: 10, test_mode: true]})
+
+    refute @handler.draining?()
+
+    conn = conn(:get, "/test123")
+    config = FT.K8S.TrafficDrainPlug.init([request_path: "/test123"])
+    conn = FT.K8S.TrafficDrainPlug.call(conn, config)
+    assert conn.status == 200
+    assert conn.halted
+    refute @handler.draining?()
+  end
+
+  test "configured path endpoint returns 500 when draining" do
+    start_supervised({@handler, [shutdown_delay_ms: 10, test_mode: self()]})
+
+    :gen_event.notify(:erl_signal_server, :sigterm)
+    assert_receive :draining
+
+    assert @handler.draining?()
+
+    conn = conn(:get, "/test123")
+    config = FT.K8S.TrafficDrainPlug.init([request_path: "/test123"])
+    conn = FT.K8S.TrafficDrainPlug.call(conn, config)
+    assert conn.status == 500
+    assert conn.halted
+
+    assert_receive {:stopping, _}
+  end
+
+  test "plug passes through other requests (/)" do
+    start_supervised({@handler, [shutdown_delay_ms: 10, test_mode: true]})
+    conn = conn(:get, "/")
+    config = FT.K8S.TrafficDrainPlug.init([])
+    conn = FT.K8S.TrafficDrainPlug.call(conn, config)
+    assert conn.status == nil
+    refute conn.halted
+  end
+
+  test "plug passes through other requests (/__whatever)" do
     start_supervised({@handler, [shutdown_delay_ms: 10, test_mode: true]})
     conn = conn(:get, "/__whatever")
-    conn = FT.K8S.TrafficDrainPlug.call(conn, [])
+    config = FT.K8S.TrafficDrainPlug.init([])
+    conn = FT.K8S.TrafficDrainPlug.call(conn, config)
+    assert conn.status == nil
+    refute conn.halted
+  end
+
+  test "plug passes through other requests (/) when path configured" do
+    start_supervised({@handler, [shutdown_delay_ms: 10, test_mode: true]})
+    conn = conn(:get, "/")
+    config = FT.K8S.TrafficDrainPlug.init([request_path: "/testabc"])
+    conn = FT.K8S.TrafficDrainPlug.call(conn, config)
+    assert conn.status == nil
+    refute conn.halted
+  end
+
+  test "plug passes through other requests (/__whatever) when path configured" do
+    start_supervised({@handler, [shutdown_delay_ms: 10, test_mode: true]})
+    conn = conn(:get, "/__whatever")
+    config = FT.K8S.TrafficDrainPlug.init([request_path: "/testabc"])
+    conn = FT.K8S.TrafficDrainPlug.call(conn, config)
+    assert conn.status == nil
+    refute conn.halted
+  end
+
+  test "plug passes through other requests (/__traffic) when path configured" do
+    start_supervised({@handler, [shutdown_delay_ms: 10, test_mode: true]})
+    conn = conn(:get, "/__traffic")
+    config = FT.K8S.TrafficDrainPlug.init([request_path: "/testabc"])
+    conn = FT.K8S.TrafficDrainPlug.call(conn, config)
     assert conn.status == nil
     refute conn.halted
   end


### PR DESCRIPTION
This PR is based on my last one, the `config_path` branch. It adds the ability to configure the ETS table name and sets the default to something more user friendly than the module name.